### PR TITLE
create /etc/dropbear for soekris

### DIFF
--- a/board/soekris/net4801/fs-overlay/etc/dropbear/readme.txt
+++ b/board/soekris/net4801/fs-overlay/etc/dropbear/readme.txt
@@ -1,0 +1,1 @@
+this directory contains the host keys for rsa and dds


### PR DESCRIPTION
create the /etc/dropbear in the fs-overlay such that init.d doesn't have to perform the (missing) mkdir
